### PR TITLE
Silence error when calling .name on None

### DIFF
--- a/dbus
+++ b/dbus
@@ -374,7 +374,7 @@ else:
 			print()
 		else:
 			print("No more arguments")
-	else:
+	elif not method is None:
 		args = eval_list(args)
 		ret = obj.object.get_dbus_method(method.name, iface.name)(*args)
 		outargs = method.args_out


### PR DESCRIPTION
Not the most graceful - cover up failure when trying to SetValue on an invalid key

Traceback (most recent call last):
  File "/usr/bin/dbus", line 379, in <module>
    ret = obj.object.get_dbus_method(method.name, iface.name)(*args)
AttributeError: 'NoneType' object has no attribute 'name'